### PR TITLE
New /status API endpoint

### DIFF
--- a/.github/workflows/ci-pipeline.yaml
+++ b/.github/workflows/ci-pipeline.yaml
@@ -10,7 +10,20 @@ jobs:
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
           version: v1.30
-  test:
+  test-out-of-cluster:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup K8s cluster
+        run: |
+          # install k3d
+          curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | bash
+          make k3d-setup
+      - name: Run out of cluster integration test
+        run: |
+          make test-out-of-cluster-setup \
+            test-out-of-cluster
+  test-in-cluster:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -20,16 +33,11 @@ jobs:
           curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
           sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
           kubectl version --client
-
-          # install k3d
-          curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | bash
       - name: Setup K8s cluster
         run: |
+          # install k3d
+          curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | bash
           make k3d-setup
-      - name: Run out of cluster integration test
-        run: |
-          make test-out-of-cluster-setup \
-            test-out-of-cluster
       - name: Run in cluster integration test
         run: |
           make image-build \

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vscode
 .user-env
+.log

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ image-build:
 #######################
 .PHONY: test-out-of-cluster-setup
 test-out-of-cluster-setup: test-out-of-cluster-clean
-	@ go run main.go --external --port 8081 &
+	@ go run main.go --external --port 8081 > .log 2>&1 &
 
 .PHONY: test-out-of-cluster-clean
 test-out-of-cluster-clean:

--- a/Makefile
+++ b/Makefile
@@ -50,10 +50,11 @@ test-out-of-cluster:
 test-in-cluster-setup: test-in-cluster-clean
 	@ kubectl apply -f integration_tests/k8s_task_runner.yaml
 	@ kubectl wait --for=condition=available --timeout=60s deployments/k8s-task-runner
-	@ sleep 5
+	@ kubectl apply -f integration_tests/k3d_ingress.yaml
 
 .PHONY: test-in-cluster-clean
 test-in-cluster-clean:
+	@ kubectl delete -f integration_tests/k3d_ingress.yaml || true
 	@ kubectl delete -f integration_tests/k8s_task_runner.yaml || true
 
 .PHONY: test-in-cluster

--- a/README.md
+++ b/README.md
@@ -34,8 +34,9 @@ The following binaries are required to run the tests:
 
 - [x] Replace `k8s.io/api/core/v1.*` in [k8sclient](./k8sclient/k8sclient.go) with Kubernetes manifest YAML files
 - [x] Add ability for users to pass in Docker credentials to pull images from private repos
-- [ ] Add basic health check API to detect if server is ready
+- [X] Add basic health check API to detect if server is ready
 - [ ] Some mechanism to clean up old task pods and secrets
+- [ ] Allow app configuration via environment variables
 - [ ] Improve API documentation. OpenAPI?
 - [ ] Image versioning needs work. It's currently statically defined under `IMAGE_VERSION` in the [Makefile](./Makefile)
 - [ ] Automatically pushing `k8s-task-runner` image to a remote Docker registry (Dockerhub?).

--- a/api/api.go
+++ b/api/api.go
@@ -5,8 +5,6 @@ import (
 	"net/http"
 	"strconv"
 
-	"k8s.io/client-go/kubernetes"
-
 	"github.com/google/uuid"
 	"github.com/gorilla/mux"
 	"github.com/leonseng/k8s_task_runner/k8sclient"
@@ -14,151 +12,170 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func HandleRequests(clientset *kubernetes.Clientset, namespace string, port int) {
+func HandleRequests(appConf ApplicationConfiguration) {
 	r := mux.NewRouter()
+	r.HandleFunc("/status", getStatus).Methods(http.MethodGet)
+	r.HandleFunc("/{id}", getTask(appConf)).Methods(http.MethodGet)
+	r.HandleFunc("/", createTask(appConf)).Methods(http.MethodPost)
 
-	/*
-		POST /
-		Create a single-run K8s pod (retartPolicy=Never) from the provided image
-
-		Request JSON parameters:
-			image: Docker image to run
-			command: Overrides command field in the container (equivalent to Docker ENTRYPOINT)
-			args: Overrides arguments defined in the container (equivalent to Docker CMD)
-			dockerRegistry:
-				server: Private Docker Registry FQDN. Use https://index.docker.io/v2/ for DockerHub.
-				username: Docker username
-				password: Docker password
-				email: Docker email
-
-		Return 201 if Job was created successfully, 400 otherwise
-
-		Response body:
-			id: Request id - used to query for status
-			request: Request JSON body as parsed by k8s-task-runner
-	*/
-	r.HandleFunc(
-		"/",
-		func(w http.ResponseWriter, r *http.Request) {
-			var reqBody CreateRequest
-			err := json.NewDecoder(r.Body).Decode(&reqBody)
-			log.Debugf("POST /\n%+v\n-----", reqBody)
-
-			if err != nil {
-				// unable to convert request body to JSON, return 400
-				http.Error(w, "Invalid request body", http.StatusBadRequest)
-				return
-			}
-
-			id := uuid.NewString()
-
-			// create secret if provided
-			var secretName string
-			if reqBody.DockerRegistry != nil {
-				secretName, err = k8sclient.CreateDockerRegistrySecret(
-					clientset,
-					k8sclient.SecretParameters{
-						ID:        id,
-						Namespace: namespace,
-						Server:    reqBody.DockerRegistry.Server,
-						Username:  reqBody.DockerRegistry.Username,
-						Email:     reqBody.DockerRegistry.Email,
-						Password:  reqBody.DockerRegistry.Password,
-					},
-				)
-				if err != nil {
-					http.Error(w, "Docker registry secret creation has failed:\n"+err.Error(), http.StatusBadRequest)
-					return
-				}
-			}
-
-			err = k8sclient.CreatePodFromManifest(
-				clientset,
-				k8sclient.PodParameters{
-					ID:        id,
-					Namespace: namespace,
-					Secret:    secretName,
-					Image:     reqBody.Image,
-					Command:   reqBody.Command,
-					Arguments: reqBody.Arguments,
-				},
-			)
-
-			if err != nil {
-				http.Error(w, "Pod creation has failed:\n"+err.Error(), http.StatusBadRequest)
-				return
-			}
-
-			w.WriteHeader(http.StatusCreated)
-			w.Header().Add("Content-Type", "application/json")
-			err = json.NewEncoder(w).Encode(
-				CreateResponse{
-					ID:      id,
-					Request: reqBody,
-				},
-			)
-			if err != nil {
-				log.Error("Failed to decode POST response body to struct")
-				http.Error(w, "Internal error", http.StatusInternalServerError)
-				return
-			}
-		},
-	).Methods(http.MethodPost)
-
-	/*
-		GET /{id}
-		Gets status of single-run pod, and container logs if test run has been completed
-
-		Path parameter:
-			id: Request id
-
-		Return 200 if no errors, 400 otherwise
-
-		Response body:
-			id: Request id
-			status: Phase of single-run pod
-			logs: Terminal output from kubectl logs <pod> command
-	*/
-	r.HandleFunc(
-		"/{id}",
-		func(w http.ResponseWriter, r *http.Request) {
-			params := mux.Vars(r)
-			id := params["id"]
-			pod, err := k8sclient.GetPod(clientset, namespace, id)
-
-			if err != nil {
-				http.Error(w, "Error getting pod "+id, http.StatusBadRequest)
-				return
-			}
-
-			respBody := GetTaskResponse{
-				ID:     id,
-				Status: string(pod.Status.Phase),
-			}
-
-			if pod.Status.Phase == "Failed" || pod.Status.Phase == "Succeeded" {
-				logs, err := k8sclient.GetPodLogs(clientset, namespace, id)
-				if err != nil {
-					http.Error(w, "Failed to get pod logs:\n"+err.Error(), http.StatusBadRequest)
-					return
-				}
-
-				respBody.Logs = logs
-			}
-
-			w.WriteHeader(http.StatusOK)
-			w.Header().Add("Content-Type", "application/json")
-			err = json.NewEncoder(w).Encode(respBody)
-			if err != nil {
-				log.Error("Failed to decode GET response body to struct")
-				http.Error(w, "Internal error", http.StatusInternalServerError)
-				return
-			}
-		},
-	).Methods(http.MethodGet)
-
-	err := http.ListenAndServe(":"+strconv.Itoa(port), r)
+	err := http.ListenAndServe(":"+strconv.Itoa(appConf.Port), r)
 	if err != nil {
 		panic(err.Error())
+	}
+}
+
+/*
+	POST /
+	Create a single-run K8s pod (retartPolicy=Never) from the provided image
+
+	Request JSON parameters:
+		image: Docker image to run
+		command: Overrides command field in the container (equivalent to Docker ENTRYPOINT)
+		args: Overrides arguments defined in the container (equivalent to Docker CMD)
+		dockerRegistry:
+			server: Private Docker Registry FQDN. Use https://index.docker.io/v2/ for DockerHub.
+			username: Docker username
+			password: Docker password
+			email: Docker email
+
+	Return 201 if Job was created successfully, 400 otherwise
+
+	Response body:
+		id: Request id - used to query for status
+		request: Request JSON body as parsed by k8s-task-runner
+*/
+func createTask(appConf ApplicationConfiguration) func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var reqBody CreateRequest
+		err := json.NewDecoder(r.Body).Decode(&reqBody)
+		log.Debugf("POST /\n%+v\n-----", reqBody)
+
+		if err != nil {
+			// unable to convert request body to JSON, return 400
+			http.Error(w, "Invalid request body", http.StatusBadRequest)
+			return
+		}
+
+		id := uuid.NewString()
+
+		// create secret if provided
+		var secretName string
+		if reqBody.DockerRegistry != nil {
+			secretName, err = k8sclient.CreateDockerRegistrySecret(
+				appConf.K8sClientSet,
+				k8sclient.SecretParameters{
+					ID:        id,
+					Namespace: appConf.TaskNamespace,
+					Server:    reqBody.DockerRegistry.Server,
+					Username:  reqBody.DockerRegistry.Username,
+					Email:     reqBody.DockerRegistry.Email,
+					Password:  reqBody.DockerRegistry.Password,
+				},
+			)
+			if err != nil {
+				http.Error(w, "Docker registry secret creation has failed:\n"+err.Error(), http.StatusBadRequest)
+				return
+			}
+		}
+
+		err = k8sclient.CreatePodFromManifest(
+			appConf.K8sClientSet,
+			k8sclient.PodParameters{
+				ID:        id,
+				Namespace: appConf.TaskNamespace,
+				Secret:    secretName,
+				Image:     reqBody.Image,
+				Command:   reqBody.Command,
+				Arguments: reqBody.Arguments,
+			},
+		)
+
+		if err != nil {
+			http.Error(w, "Pod creation has failed:\n"+err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		w.WriteHeader(http.StatusCreated)
+		w.Header().Add("Content-Type", "application/json")
+		err = json.NewEncoder(w).Encode(
+			CreateResponse{
+				ID:      id,
+				Request: reqBody,
+			},
+		)
+		if err != nil {
+			log.Error("Failed to encode POST response struct to JSON")
+			http.Error(w, "Internal error", http.StatusInternalServerError)
+			return
+		}
+	}
+}
+
+/*
+	GET /status
+	Gets status of the k8s-task-runner application
+
+	Return 200
+
+	Response body:
+		status: Returns health of application: healthy
+*/
+func getStatus(w http.ResponseWriter, r *http.Request) {
+	err := json.NewEncoder(w).Encode(GetStatusResponse{Status: "healthy"})
+	if err != nil {
+		log.Error("Failed to encode GET app status response struct to JSON")
+		http.Error(w, "Internal error", http.StatusInternalServerError)
+		return
+	}
+}
+
+/*
+	GET /{id}
+	Gets status of single-run pod, and container logs if test run has been completed
+
+	Path parameter:
+		id: Request id
+
+	Return 200 if no errors, 400 otherwise
+
+	Response body:
+		id: Request id
+		status: Phase of single-run pod
+		logs: Terminal output from kubectl logs <pod> command
+*/
+func getTask(appConf ApplicationConfiguration) func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		params := mux.Vars(r)
+		id := params["id"]
+		pod, err := k8sclient.GetPod(appConf.K8sClientSet, appConf.TaskNamespace, id)
+
+		if err != nil {
+			http.Error(w, "Error getting pod "+id, http.StatusBadRequest)
+			return
+		}
+
+		respBody := GetTaskResponse{
+			ID:     id,
+			Status: string(pod.Status.Phase),
+		}
+
+		if pod.Status.Phase == "Failed" || pod.Status.Phase == "Succeeded" {
+			logs, err := k8sclient.GetPodLogs(appConf.K8sClientSet, appConf.TaskNamespace, id)
+			if err != nil {
+				http.Error(w, "Failed to get pod logs:\n"+err.Error(), http.StatusBadRequest)
+				return
+			}
+
+			respBody.Logs = logs
+		}
+
+		w.WriteHeader(http.StatusOK)
+		w.Header().Add("Content-Type", "application/json")
+		err = json.NewEncoder(w).Encode(respBody)
+		if err != nil {
+			log.Error("Failed to encode GET task status response struct to JSON")
+			http.Error(w, "Internal error", http.StatusInternalServerError)
+			return
+		}
 	}
 }

--- a/api/api.go
+++ b/api/api.go
@@ -131,7 +131,7 @@ func HandleRequests(clientset *kubernetes.Clientset, namespace string, port int)
 				return
 			}
 
-			respBody := GetResponse{
+			respBody := GetTaskResponse{
 				ID:     id,
 				Status: string(pod.Status.Phase),
 			}

--- a/api/apistructs.go
+++ b/api/apistructs.go
@@ -19,7 +19,7 @@ type CreateResponse struct {
 	Request CreateRequest `json:"request"`
 }
 
-type GetResponse struct {
+type GetTaskResponse struct {
 	ID     string `json:"id"`
 	Status string `json:"status"`
 	Logs   string `json:"logs"`

--- a/api/apistructs.go
+++ b/api/apistructs.go
@@ -1,5 +1,15 @@
 package api
 
+import (
+	"k8s.io/client-go/kubernetes"
+)
+
+type ApplicationConfiguration struct {
+	Port          int
+	K8sClientSet  *kubernetes.Clientset
+	TaskNamespace string
+}
+
 type DockerRegistry struct {
 	Server   string `json:"server,omitempty"`
 	Username string `json:"username,omitempty"`
@@ -23,4 +33,8 @@ type GetTaskResponse struct {
 	ID     string `json:"id"`
 	Status string `json:"status"`
 	Logs   string `json:"logs"`
+}
+
+type GetStatusResponse struct {
+	Status string `json:"status"`
 }

--- a/integration_tests/api_test.go
+++ b/integration_tests/api_test.go
@@ -54,7 +54,7 @@ func runIntegrationTest(t *testing.T, apiEndpoint string) {
 	}
 
 	// wait for pod to run to completion
-	getRespBody := new(api.GetResponse)
+	getRespBody := new(api.GetTaskResponse)
 	var getResp *http.Response
 	for i := 0; i < 30; i++ {
 		getResp, err = http.Get(apiEndpoint + createRespBody.ID)

--- a/integration_tests/api_test.go
+++ b/integration_tests/api_test.go
@@ -35,6 +35,10 @@ func getStatus(t *testing.T, apiEndpoint string) {
 	respBody := new(api.GetStatusResponse)
 	fmt.Printf("%+v\n", resp.Body)
 	err = json.NewDecoder(resp.Body).Decode(respBody)
+	if err != nil {
+		t.Errorf("Failed to decode GET response body to JSON")
+	}
+
 	assert.Equal(t, respBody.Status, "healthy")
 }
 

--- a/integration_tests/api_test.go
+++ b/integration_tests/api_test.go
@@ -21,6 +21,24 @@ func TestOutOfCluster(t *testing.T) {
 }
 
 func runIntegrationTest(t *testing.T, apiEndpoint string) {
+	getStatus(t, apiEndpoint)
+	createAndGetTask(t, apiEndpoint)
+}
+
+func getStatus(t *testing.T, apiEndpoint string) {
+	resp, err := http.Get(apiEndpoint + "/status")
+	if err != nil {
+		t.Errorf("Failed to get app status: %v\n", err)
+	}
+
+	defer resp.Body.Close()
+	respBody := new(api.GetStatusResponse)
+	fmt.Printf("%+v\n", resp.Body)
+	err = json.NewDecoder(resp.Body).Decode(respBody)
+	assert.Equal(t, respBody.Status, "healthy")
+}
+
+func createAndGetTask(t *testing.T, apiEndpoint string) {
 	reqBody := api.CreateRequest{
 		Image:   "busybox:1.28",
 		Command: []string{"date"},

--- a/integration_tests/k3d_ingress.yaml
+++ b/integration_tests/k3d_ingress.yaml
@@ -1,0 +1,19 @@
+---
+# This is to route requests from localhost into k3d cluster network
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: nginx
+  annotations:
+    ingress.kubernetes.io/ssl-redirect: "false"
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: k8s-task-runner-svc
+            port:
+              number: 80

--- a/integration_tests/k8s_task_runner.yaml
+++ b/integration_tests/k8s_task_runner.yaml
@@ -61,6 +61,18 @@ spec:
         name: k8s-task-runner
         resources: {}
         imagePullPolicy: Always
+        livenessProbe:
+          httpGet:
+            path: /status
+            port: 80
+          failureThreshold: 6
+          periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /status
+            port: 80
+          failureThreshold: 3
+          periodSeconds: 3
 status: {}
 ---
 apiVersion: v1
@@ -79,22 +91,3 @@ spec:
     app: k8s-task-runner
 status:
   loadBalancer: {}
----
-# This is to route requests from localhost into k3d cluster network
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  name: nginx
-  annotations:
-    ingress.kubernetes.io/ssl-redirect: "false"
-spec:
-  rules:
-  - http:
-      paths:
-      - path: /
-        pathType: Prefix
-        backend:
-          service:
-            name: k8s-task-runner-svc
-            port:
-              number: 80

--- a/main.go
+++ b/main.go
@@ -32,7 +32,13 @@ func main() {
 		panic(err.Error())
 	}
 
-	api.HandleRequests(clientSet, inputs.namespace, inputs.port)
+	api.HandleRequests(
+		api.ApplicationConfiguration{
+			Port:          inputs.port,
+			K8sClientSet:  clientSet,
+			TaskNamespace: inputs.namespace,
+		},
+	)
 }
 
 func parseUserInputs() userInputs {


### PR DESCRIPTION
- New Status API `/status` endpoint
- Updated in cluster deployment with liveness and readiness probe to use Status API
- `test-out-of-cluster` target now stores app logs in `.log` file
- Added new structs to clean up how parameters are passed around